### PR TITLE
Avoid skb bulk free, our page allocator does not need it

### DIFF
--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -976,6 +976,17 @@ static inline void _kfree_skb_defer(struct sk_buff *skb)
 	/* drop skb->head and call any destructors for packet */
 	skb_release_all(skb);
 
+	/*
+	 * Tempesta uses its own fast page allocator for socket buffers,
+	 * so no need to use napi_alloc_cache for paged skbs.
+	 */
+#ifdef CONFIG_SECURITY_TEMPESTA
+	if (skb->skb_page) {
+		put_page(virt_to_head_page(skb));
+		return;
+	}
+#endif
+
 	/* record skb to CPU local list */
 	nc->skb_cache[nc->skb_count++] = skb;
 


### PR DESCRIPTION
Fix https://github.com/tempesta-tech/tempesta/issues/697 . The bug is introduced by at least these patches in 4.8.15:

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=795bb1c00dd338aa0d12f9a7f1f4776fb3160416
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=15fad714be86eab13e7568fecaf475b2a9730d3e
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a3a8749d34d8a5ac071c7ead792bd21ffe328aa0
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8220bbc12d39175964cb56e100fabcedd59c48da

Basically, the problem is that we allocate a skb using our page allocator and free it using kmem_cache, so this fix can influence other crash/leak bugs.